### PR TITLE
Add IBM Digital Analytics to plugin list

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,7 @@
         <li><a tabindex="-1" href="#plugins" analytics-on analytics-category="Navigation" analytics-event="Google Tag Manager">Google Tag Manager</a></li>
         <li><a tabindex="-1" href="#plugins" analytics-on analytics-category="Navigation" analytics-event="GoSquared">GoSquared</a></li>
         <li><a tabindex="-1" href="#plugins" analytics-on analytics-category="Navigation" analytics-event="Hubspot">Hubspot</a></li>
+        <li><a tabindex="-1" href="#plugins" analytics-on analytics-category="Navigation" analytics-event="IBM Digital Analytics">IBM Digital Analytics</a></li>
         <li><a tabindex="-1" href="#plugins" analytics-on analytics-category="Navigation" analytics-event="Inspectlet">Inspectlet</a></li>
         <li><a tabindex="-1" href="#plugins" analytics-on analytics-category="Navigation" analytics-event="Intercom">Intercom</a></li>
         <li><a tabindex="-1" href="#plugins" analytics-on analytics-category="Navigation" analytics-event="Kissmetrics">Kissmetrics</a></li>
@@ -302,6 +303,14 @@
       <td>Yes</td>
       <td><a href="https://github.com/angulartics/angulartics/blob/master/src/angulartics-hubspot.js" analytics-on analytics-category="Sources" analytics-event="angulartics-hubspot.js">angulartics-hubspot</a></td>
       <td><code>angulartics.hubspot</code></td>
+      <td></td>
+    </tr>
+    <tr>
+      <th>IBM Digital Analytics</th>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td><a href="https://github.com/cwill747/angulartics-coremetrics" analytics-on analytics-category="Sources" analytics-event="angulartics-coremetrics.js">angulartics-coremetrics</a></td>
+      <td><code>angulartics.coremetrics</code></td>
       <td></td>
     </tr>
     <tr>


### PR DESCRIPTION
IBM Digital Analytics was already added on the github repo, just not added on the github.io site. Adding it there as well with a link to the repo.
